### PR TITLE
Update proprietary tag

### DIFF
--- a/io.itch.nordup.TheGates.yml
+++ b/io.itch.nordup.TheGates.yml
@@ -3,8 +3,6 @@ runtime: org.freedesktop.Platform
 runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: TheGates
-tags:
-  - proprietary
 cleanup:
   - '*.cmake'
   - '*.a'


### PR DESCRIPTION
Project use the MIT license. This tag is redundant.