### PR TITLE
rebuild 1.0.0 — bump release date to retrigger flathub build

### DIFF
--- a/io.itch.nordup.TheGates.appdata.xml
+++ b/io.itch.nordup.TheGates.appdata.xml
@@ -33,7 +33,7 @@ Follow the portals to travel between these worlds and discover the ones that tru
   </screenshots>
   <releases>
 
-    <release version="1.0.0" date="2026-05-25">
+    <release version="1.0.0" date="2026-05-26">
       <description>
         <p>TheGates 1.0 — first stable release. Cross-platform sandboxing on Windows, Linux, macOS.</p>
       </description>


### PR DESCRIPTION
The 1.0.0 build (PR #98) merged a day ago but Flathub is still publishing 0.24.4 — the build likely failed silently. Bumping the release date in appdata.xml to retrigger the build pipeline without changing the version.

No code/manifest changes.