### PR TITLE
update to 1.0.1 - Fix launcher rendering on Wayland sessions

### DIFF
--- a/io.itch.nordup.TheGates.appdata.xml
+++ b/io.itch.nordup.TheGates.appdata.xml
@@ -33,6 +33,12 @@ Follow the portals to travel between these worlds and discover the ones that tru
   </screenshots>
   <releases>
 
+    <release version="1.0.1" date="2026-05-27">
+      <description>
+        <p>Fix launcher rendering on Wayland sessions — launcher now uses XWayland, renderer keeps native Wayland.</p>
+      </description>
+    </release>
+
     <release version="1.0.0" date="2026-05-26">
       <description>
         <p>TheGates 1.0 — first stable release. Cross-platform sandboxing on Windows, Linux, macOS.</p>

--- a/io.itch.nordup.TheGates.yml
+++ b/io.itch.nordup.TheGates.yml
@@ -1,6 +1,6 @@
 app-id: io.itch.nordup.TheGates
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: TheGates
 cleanup:

--- a/io.itch.nordup.TheGates.yml
+++ b/io.itch.nordup.TheGates.yml
@@ -12,7 +12,7 @@ finish-args:
   - '--share=ipc'
   - '--socket=pulseaudio'
   - '--socket=wayland'
-  - '--socket=fallback-x11'
+  - '--socket=x11'
   - '--device=dri'
   - '--device=all'
 modules:
@@ -28,7 +28,7 @@ modules:
       - 'install -Dm644 icon_512.png /app/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png'
     sources:
       - type: archive
-        dest-filename: TheGates_Linux_1.0.0.zip
+        dest-filename: TheGates_Linux_1.0.1.zip
         url: 'https://thegates.io/downloads/linux-latest'
         sha256: a66d864bbf1e59f9371b4247a1975a010e397c89ca112844ec2f580e6e0d4432
       - type: file


### PR DESCRIPTION
## Summary
- **Launcher rendering fix**: swap `--socket=fallback-x11` → `--socket=x11` so the X11 socket is actually exposed inside the sandbox on Wayland sessions. The launcher Godot binary defaults to x11 and now correctly uses XWayland; the renderer is already invoked by the launcher with `--display-driver wayland`, so it keeps native Wayland.
- **Runtime bump**: `org.freedesktop.Platform` 24.08 → 25.08, resolves the linter warning from the previous test build.
- Adds a `1.0.1` entry to the appdata changelog. The underlying game binary at `linux-latest` is unchanged (same sha256 as 1.0.0); this is a manifest-only fix.

## Test plan
- [ ] flathubbot test build passes (manifest validates, build succeeds)
- [ ] linter warning about runtime 25.08 is gone
- [ ] On a Wayland session, after `flatpak install` of the test build, the launcher uses XWayland (no Wayland-specific UI bugs) and the renderer process uses native Wayland
- [ ] On an X11-only session, both processes use X11 as before