### PR TITLE
update to 1.0.2 - Fix launcher startup on X11 + shader cache freezes

### DIFF
--- a/io.itch.nordup.TheGates.appdata.xml
+++ b/io.itch.nordup.TheGates.appdata.xml
@@ -33,6 +33,12 @@ Follow the portals to travel between these worlds and discover the ones that tru
   </screenshots>
   <releases>
 
+    <release version="1.0.2" date="2026-06-14">
+      <description>
+        <p>Fix launcher crash on startup on X11 sessions and shader cache freezes on Linux</p>
+      </description>
+    </release>
+
     <release version="1.0.1" date="2026-05-29">
       <description>
         <p>Verbose renderer logging for better crash diagnostics</p>

--- a/io.itch.nordup.TheGates.yml
+++ b/io.itch.nordup.TheGates.yml
@@ -28,9 +28,9 @@ modules:
       - 'install -Dm644 icon_512.png /app/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png'
     sources:
       - type: archive
-        dest-filename: TheGates_Linux_1.0.1.zip
+        dest-filename: TheGates_Linux_1.0.2.zip
         url: 'https://thegates.io/downloads/linux-latest'
-        sha256: da8f011cb7b19504e4ec179f843e5a2276e55297a9dd7185fef839966c8680b4
+        sha256: e292e83c553ad4df390ef28fec18675906fc62816c448281d544046190aa23c1
       - type: file
         path: gates.desktop
       - type: file


### PR DESCRIPTION
Bump to 1.0.2.

Linux fixes in this build:
- Launcher failed to start on X11 / Xwayland sessions (the sandbox env filter dropped `XAUTHORITY`, so the renderer couldn't authenticate to the X server). Now passed through.
- The GPU driver shader cache was blocked by the sandbox (landlock), disabling caching and causing shader-recompile freezes. Now redirected into the gate's writable dir.

Build is served from the existing `https://thegates.io/downloads/linux-latest` URL; only `dest-filename` + `sha256` change. sha256 verified against the uploaded zip.