### PR TITLE
update to 1.0.3 - Fix 4.3-gate renderer crash on bootup on Linux

### DIFF
--- a/io.itch.nordup.TheGates.appdata.xml
+++ b/io.itch.nordup.TheGates.appdata.xml
@@ -33,6 +33,12 @@ Follow the portals to travel between these worlds and discover the ones that tru
   </screenshots>
   <releases>
 
+    <release version="1.0.3" date="2026-06-15">
+      <description>
+        <p>Fix 4.3-gate renderer crash on bootup on Linux (raise renderer open-file limit in the sandbox)</p>
+      </description>
+    </release>
+
     <release version="1.0.2" date="2026-06-14">
       <description>
         <p>Fix launcher crash on startup on X11 sessions and shader cache freezes on Linux</p>

--- a/io.itch.nordup.TheGates.yml
+++ b/io.itch.nordup.TheGates.yml
@@ -28,9 +28,9 @@ modules:
       - 'install -Dm644 icon_512.png /app/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png'
     sources:
       - type: archive
-        dest-filename: TheGates_Linux_1.0.2.zip
+        dest-filename: TheGates_Linux_1.0.3.zip
         url: 'https://thegates.io/downloads/linux-latest'
-        sha256: e292e83c553ad4df390ef28fec18675906fc62816c448281d544046190aa23c1
+        sha256: 7f60085ed2ca48a0168a2092f62fea02ae324517abe13e54657d8fda27960518
       - type: file
         path: gates.desktop
       - type: file


### PR DESCRIPTION
Fixes a renderer boot crash ("Gate crashed on bootup") on Linux for gates built against the 4.3 renderer.

On hosts where the desktop session hands the renderer a low open-file soft limit (RLIMIT_NOFILE), the GPU driver runs out of file descriptors at swapchain creation, failing every Vulkan allocation with VK_ERROR_OUT_OF_HOST_MEMORY before the first frame. The launcher now raises the renderer child's NOFILE soft limit to the hard ceiling just before launching it (idempotent — a no-op when soft already equals hard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)