### PR TITLE
update to 1.0.4 - Fix gates that could fail to start on some Linux (Wayland) systems

### DIFF
--- a/io.itch.nordup.TheGates.appdata.xml
+++ b/io.itch.nordup.TheGates.appdata.xml
@@ -33,6 +33,12 @@ Follow the portals to travel between these worlds and discover the ones that tru
   </screenshots>
   <releases>
 
+    <release version="1.0.4" date="2026-06-16">
+      <description>
+        <p>Fix gates that could fail to start on some Linux (Wayland) systems</p>
+      </description>
+    </release>
+
     <release version="1.0.3" date="2026-06-15">
       <description>
         <p>Fix 4.3-gate renderer crash on bootup on Linux (raise renderer open-file limit in the sandbox)</p>

--- a/io.itch.nordup.TheGates.yml
+++ b/io.itch.nordup.TheGates.yml
@@ -28,9 +28,9 @@ modules:
       - 'install -Dm644 icon_512.png /app/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png'
     sources:
       - type: archive
-        dest-filename: TheGates_Linux_1.0.3.zip
+        dest-filename: TheGates_Linux_1.0.4.zip
         url: 'https://thegates.io/downloads/linux-latest'
-        sha256: 7f60085ed2ca48a0168a2092f62fea02ae324517abe13e54657d8fda27960518
+        sha256: df3c552d398cbfe955f4dd081b848390fd33723713d3309496dea43c0bf9c3af
       - type: file
         path: gates.desktop
       - type: file


### PR DESCRIPTION
Updates the bundled Linux build to TheGates 1.0.4.

Fix: gates could fail to start on some Linux/Wayland systems — the invisible renderer surface got no compositor frame callbacks and suspended before the first frame. The bundled renderer now keeps drawing off-screen regardless of compositor suspend. Renderer-side change; launcher + bundled renderer refreshed. sha256 of TheGates_Linux_1.0.4.zip matches the published download.