### PR TITLE
update to 1.0.5 - fix worlds failing to load after an interrupted download

### DIFF
--- a/io.itch.nordup.TheGates.appdata.xml
+++ b/io.itch.nordup.TheGates.appdata.xml
@@ -33,6 +33,12 @@ Follow the portals to travel between these worlds and discover the ones that tru
   </screenshots>
   <releases>
 
+    <release version="1.0.5" date="2026-06-16">
+      <description>
+        <p>Fixed some worlds failing to load after an interrupted download — the launcher now retries automatically.</p>
+      </description>
+    </release>
+
     <release version="1.0.4" date="2026-06-16">
       <description>
         <p>Fix gates that could fail to start on some Linux (Wayland) systems</p>

--- a/io.itch.nordup.TheGates.yml
+++ b/io.itch.nordup.TheGates.yml
@@ -28,9 +28,9 @@ modules:
       - 'install -Dm644 icon_512.png /app/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png'
     sources:
       - type: archive
-        dest-filename: TheGates_Linux_1.0.4.zip
+        dest-filename: TheGates_Linux_1.0.5.zip
         url: 'https://thegates.io/downloads/linux-latest'
-        sha256: df3c552d398cbfe955f4dd081b848390fd33723713d3309496dea43c0bf9c3af
+        sha256: cba197f1829a230970203ca36b30c829924c4f438274ca6f40d0f58938481c70
       - type: file
         path: gates.desktop
       - type: file


### PR DESCRIPTION
Launcher-only release (no renderer change).

Fixes a bug where a world could fail to load if its download was interrupted: an interrupted transfer (a dropped connection still arrives as HTTP 200 with a short body) was treated as complete/cached, and a connection-level failure was misread as "already downloaded", surfacing as "Renderer executable not found" with no retry. The launcher now verifies downloaded bytes against Content-Length, rejects partial transfers, and retries the renderer download automatically.

Verified on Linux via the autotest harness: clean first-launch and the previously-wedged truncated-download case both reach first frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)