### PR TITLE
update to 1.0.6 - fix NVIDIA sandbox GPU allocations + renderer crash

### DIFF
--- a/io.itch.nordup.TheGates.appdata.xml
+++ b/io.itch.nordup.TheGates.appdata.xml
@@ -33,6 +33,12 @@ Follow the portals to travel between these worlds and discover the ones that tru
   </screenshots>
   <releases>
 
+    <release version="1.0.6" date="2026-07-09">
+      <description>
+        <p>Fix gates failing on NVIDIA GPUs (sandbox blocked driver allocations) and a renderer crash</p>
+      </description>
+    </release>
+
     <release version="1.0.5" date="2026-06-16">
       <description>
         <p>Fixed some worlds failing to load after an interrupted download — the launcher now retries automatically.</p>

--- a/io.itch.nordup.TheGates.yml
+++ b/io.itch.nordup.TheGates.yml
@@ -28,9 +28,9 @@ modules:
       - 'install -Dm644 icon_512.png /app/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png'
     sources:
       - type: archive
-        dest-filename: TheGates_Linux_1.0.5.zip
+        dest-filename: TheGates_Linux_1.0.6.zip
         url: 'https://thegates.io/downloads/linux-latest'
-        sha256: cba197f1829a230970203ca36b30c829924c4f438274ca6f40d0f58938481c70
+        sha256: ca32486f50c9049c1e586bf5b8e1528db622ec605e080982e3502e2258818142
       - type: file
         path: gates.desktop
       - type: file


### PR DESCRIPTION
Fix gates failing on NVIDIA GPUs: the renderer's Landlock sandbox never granted the /dev/nvidia* device nodes, so on newer NVIDIA drivers every Vulkan allocation made after lockdown failed (gates hung or crashed, text rendered with missing glyphs). The sandbox now grants the same NVIDIA node set Chromium's GPU sandbox uses, plus Flatpak host-font mounts, and the renderer no longer SEGVs when a GPU allocation fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JoFvaw6XC4LbkFzMGjBRn