### PR TITLE
update to 1.0.7 - renderer updates reach existing installs

### DIFF
--- a/io.itch.nordup.TheGates.appdata.xml
+++ b/io.itch.nordup.TheGates.appdata.xml
@@ -33,6 +33,12 @@ Follow the portals to travel between these worlds and discover the ones that tru
   </screenshots>
   <releases>
 
+    <release version="1.0.7" date="2026-07-09">
+      <description>
+        <p>Renderer updates now reach existing installs — previously a cached world renderer was never refreshed after download</p>
+      </description>
+    </release>
+
     <release version="1.0.6" date="2026-07-09">
       <description>
         <p>Fix gates failing on NVIDIA GPUs (sandbox blocked driver allocations) and a renderer crash</p>

--- a/io.itch.nordup.TheGates.yml
+++ b/io.itch.nordup.TheGates.yml
@@ -28,9 +28,9 @@ modules:
       - 'install -Dm644 icon_512.png /app/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png'
     sources:
       - type: archive
-        dest-filename: TheGates_Linux_1.0.6.zip
+        dest-filename: TheGates_Linux_1.0.7.zip
         url: 'https://thegates.io/downloads/linux-latest'
-        sha256: ca32486f50c9049c1e586bf5b8e1528db622ec605e080982e3502e2258818142
+        sha256: 05731e5f5bf4dbe5cbfb60693457ac9aebea0d0c75f3d65c40f9c8d96a83a04e
       - type: file
         path: gates.desktop
       - type: file


### PR DESCRIPTION
The launcher previously never refreshed a world renderer it had already extracted, so renderer fixes (like 1.0.6's NVIDIA sandbox fix for 4.3 worlds) only reached first-time visitors. The launcher now re-extracts when the server's renderer package changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JoFvaw6XC4LbkFzMGjBRn